### PR TITLE
Feature #2 isInAreaの置き換え

### DIFF
--- a/src/n_tracs_soyabridge/area.lua
+++ b/src/n_tracs_soyabridge/area.lua
@@ -35,7 +35,7 @@ function Area.isInArea(self, pos)
     for i, v0 in polygon do
         local v1 = polygon[(i + 1) % n]
         prod = Complex.mul(prod,
-            Complex.sqrt(
+            Complex.halfArgument(
                 Complex.mul(
                     Complex.new(v1.x - x, v1.z - z),
                     Complex.conjugate(Complex.new(v0.x - x, v0.z - z))

--- a/src/n_tracs_soyabridge/area.lua
+++ b/src/n_tracs_soyabridge/area.lua
@@ -1,3 +1,5 @@
+require('src.utils.complex')
+
 ---@type Area
 Area = Area or {}
 
@@ -28,26 +30,17 @@ end
 ---@return boolean
 function Area.isInArea(self, pos)
     local polygon, x, z = self.vertexs, pos.x, pos.z
-
-    local f, vt
-    f = false
-    for i = 1, (#polygon - 1) do
-        if ((polygon[i].z <= z) and polygon[i + 1].z > z)
-            or ((polygon[i].z > z) and polygon[i + 1].z <= z) then
-            vt = (z - polygon[i].z) / (polygon[i + 1].z - polygon[i].z)
-            if x < (polygon[i].x + (vt * (polygon[i + 1].x - polygon[i].x))) then
-                f = not f
-            end
-        end
+    local n = #polygon
+    local prod = Complex.new(1, 0)
+    for i, v0 in polygon do
+        local v1 = polygon[(i + 1) % n]
+        prod = prod:mul(
+            Complex.new(v1.x - x, v1.z - z):mul(
+                Complex.new(v0.x - x, v0.z - z):conjugate()
+            ):sqrt()
+        )
     end
-    if ((polygon[#polygon].z <= z) and polygon[1].z > z)
-        or ((polygon[#polygon].z > z) and polygon[1].z <= z) then
-        vt = (z - polygon[#polygon].z) / (polygon[1].z - polygon[#polygon].z)
-        if x < (polygon[#polygon].x + (vt * (polygon[1].x - polygon[#polygon].x))) then
-            f = not f
-        end
-    end
-    return f
+    return prod.re < 0
 end
 
 function Len2(v1, v2)

--- a/src/n_tracs_soyabridge/area.lua
+++ b/src/n_tracs_soyabridge/area.lua
@@ -34,10 +34,13 @@ function Area.isInArea(self, pos)
     local prod = Complex.new(1, 0)
     for i, v0 in polygon do
         local v1 = polygon[(i + 1) % n]
-        prod = prod:mul(
-            Complex.new(v1.x - x, v1.z - z):mul(
-                Complex.new(v0.x - x, v0.z - z):conjugate()
-            ):sqrt()
+        prod = Complex.mul(prod,
+            Complex.sqrt(
+                Complex.mul(
+                    Complex.new(v1.x - x, v1.z - z),
+                    Complex.conjugate(Complex.new(v0.x - x, v0.z - z))
+                )
+            )
         )
     end
     return prod.re < 0

--- a/src/utils/complex.lua
+++ b/src/utils/complex.lua
@@ -14,39 +14,39 @@ function Complex.new(re, im)
 end
 
 ---共役
----@params self Complex
+---@params a Complex
 ---@returns Complex
-function Complex.conjugate(self)
+function Complex.conjugate(a)
     return {
-        re = self.re,
-        im = -self.im
+        re = a.re,
+        im = -a.im
     }
 end
 
 ---乗算
----@params self Complex
+---@params a Complex
 ---@params b Complex
 ---@returns Complex
-function Complex.mul(self, b)
+function Complex.mul(a, b)
     return {
-        re = self.re * b.re - self.im * b.im,
-        im = self.re * b.im + b.re * self.im
+        re = a.re * b.re - a.im * b.im,
+        im = a.re * b.im + b.re * a.im
     }
 end
 
 ---1/2乗
----@params self Complex
+---@params a Complex
 ---@return Complex
-function Complex.sqrt(self)
-    local r = math.sqrt(self.re ^ 2 + self.im ^ 2);
+function Complex.sqrt(a)
+    local r = math.sqrt(a.re ^ 2 + a.im ^ 2);
     local sign = 0
-    if self.im > 0 then
+    if a.im > 0 then
         sign = 1
-    elseif self.im < 0 then
+    elseif a.im < 0 then
         sign = -1
     end
     return {
-        re = math.sqrt((self.re + r) / 2),
-        im = sign * math.sqrt((-self.re + r) / 2)
+        re = math.sqrt((a.re + r) / 2),
+        im = sign * math.sqrt((-a.re + r) / 2)
     }
 end

--- a/src/utils/complex.lua
+++ b/src/utils/complex.lua
@@ -1,0 +1,52 @@
+---@class Complex
+Complex = Complex or {}
+
+---複素数
+---@class Complex
+---@field re number @実部
+---@field im number @虚部
+
+function Complex.new(re, im)
+    return {
+        re = re,
+        im = im
+    }
+end
+
+---共役
+---@params self Complex
+---@returns Complex
+function Complex.conjugate(self)
+    return {
+        re = self.re,
+        im = -self.im
+    }
+end
+
+---乗算
+---@params self Complex
+---@params b Complex
+---@returns Complex
+function Complex.mul(self, b)
+    return {
+        re = self.re * b.re - self.im * b.im,
+        im = self.re * b.im + b.re * self.im
+    }
+end
+
+---1/2乗
+---@params self Complex
+---@return Complex
+function Complex.sqrt(self)
+    local r = math.sqrt(self.re ^ 2 + self.im ^ 2);
+    local sign = 0
+    if self.im > 0 then
+        sign = 1
+    elseif self.im < 0 then
+        sign = -1
+    end
+    return {
+        re = math.sqrt((self.re + r) / 2),
+        im = sign * math.sqrt((-self.re + r) / 2)
+    }
+end

--- a/src/utils/complex.lua
+++ b/src/utils/complex.lua
@@ -34,11 +34,11 @@ function Complex.mul(a, b)
     }
 end
 
----1/2乗
+---偏角1/2倍、絶対値1/2乗の値を求める 偏角は-90度～0度～90度の範囲になる
 ---@params a Complex
 ---@return Complex
-function Complex.sqrt(a)
-    local r = math.sqrt(a.re ^ 2 + a.im ^ 2);
+function Complex.halfArgument(a)
+    local r = math.sqrt(a.re ^ 2 + a.im ^ 2)
     local sign = 0
     if a.im > 0 then
         sign = 1


### PR DESCRIPTION
src/utils/complex.lua に複素数計算用のクラスを用意しました。
複素数計算を利用して、`Area.isInArea` の中身をまるごと置き換えました。
点から多角形の各頂点を順番に見たとき、一周したら多角形の中、しなければ外と判定する Winding Number Algorithm をベースとしていますが、点から頂点を見た相対座標を複素数として解釈し、次々に乗算していけば偏角が次々に積算されていくというのを利用しています。そのまま積算すると360度と0度の区別はつきませんが、毎回1/2乗してから乗算することで、一周したときに偏角が180度になるようにしています。最終的には実部の符号が負であれば一周したとみなし、多角形の中だと判定します。