### PR TITLE
過走防護フォールバック(overrun_lock_fallback)と開通てこ(OpeningLever)を追加

### DIFF
--- a/SPEC_CORE.md
+++ b/SPEC_CORE.md
@@ -255,7 +255,54 @@ HR = ZR AND isLocked AND checkWLR AND NOT(TSSlR) AND NOT(ASR) AND isNoShort
 
 `controls` グラフの循環（A→B→A など）はビルド時（`generate_signal.js`）に DFS で検出されてエラーになります。このためランタイムでは循環による無限ループは発生しません。
 
-### 4.7 AutoSignal
+### 4.7 過走防護フォールバック（`overrunLockFallback` / `HyR`）
+
+過走防護区間（`overrunLock`）が仮予約できない場合、通常はてこ全体の仮予約が失敗し、信号は停止現示のまま固まります。`overrunLockFallback`（TOML: `overrun_lock_fallback = true`）を有効にした信号てこに限り、過走防護区間の仮予約が失敗しても発点・進路鎖錠・着点の本予約は進行させ、代わりに警戒信号現示リレー `HyR` を true にします。現示番号（何を出すか）はコア側では決めず、`update_callback` 側で `lever.HyR` を参照して決定します（コアは `nextAspect` をクランプしません）。
+
+#### `bookTemporary` の変更点
+
+過走防護区間だけを別枠でチェックするようにし、オール・オア・ナッシングの対象から外します。
+
+```
+発点 is_ready_for_book_start? → routeLock(各) is_ready_for_book_temporary?
+→ 着点 is_ready_for_book_temporary?              ← ここまでは従来通りアトミック
+→ overrunLock(各) is_ready_for_book_temporary?    ← 結果を overrunReady に記録するのみ
+→ overrunReady が false かつ overrunLockFallback が false → 全体スキップ（従来通り）
+→ それ以外は発点・routeLock・着点を書き込み
+→ overrunReady が true のときだけ overrunLock も書き込む（フォールバック時は過走防護区間を空けておく）
+```
+
+`overrunLockFallback` が有効でも `overrunReady` が false の場合、過走防護区間の `book_temporary()` 呼び出しは一切行いません。これにより、他進路や開通てこ（6.7節参照）がその区間を引き続き利用できます。
+
+#### `isBookedTemporary` / `isLocked` の変更点
+
+`overrunLockFallback` が true の信号は、`isBookedTemporary`・`isLocked` の両方で過走防護区間の成否チェックをスキップし、常に成立したものとして扱います（発点・routeLock・着点の判定は従来通り必須）。
+
+#### 本予約確定時の安全ガード
+
+`Signal:process()` の本予約格上げブロックでは、過走防護区間への `book_over_run()` 呼び出しに以下のガードを追加しています。
+
+```lua
+for _, track in ipairs(self.overrunLock) do
+    local t = nt:get_track(track)
+    if t:is_booked_temporary(self.itemName, nt) and not t:is_over_run_lock(self.itemName, nt) then
+        t:book_over_run(self.itemName, nt)
+    end
+end
+```
+
+- `is_booked_temporary`：自分が確かにその区間を仮予約できている場合のみ本予約に格上げする（フォールバックで見送った区間は対象外）。
+- `not is_over_run_lock`：既に（開通てこ経由などで）保護が成立している区間は、所有権を奪って `book_over_run()` を呼び直さない（6.7節参照）。
+
+#### HyR（警戒信号現示リレー）
+
+```
+HyR = HR AND NOT(isOverrunProtected)
+```
+
+`isOverrunProtected(nt)` は `isLocked` から切り出した過走防護専用の判定で、`overrunLockFallback` を考慮せず「overrunLock 全区間が `is_over_run_lock` を満たすか」だけを返します。`HR` が成立していても過走防護が完全でない（フォールバックで通した）場合に `HyR` が true になります。
+
+### 4.8 AutoSignal
 
 `Signal` の簡略版で、てこ入力・進路鎖錠機能を持たず、**在線なし（signalTrack全て空）→ HR=true** の単純なルールで現示を計算します。`HR` は `new()` では初期化されず、初回 `process()` で設定されます。
 
@@ -400,6 +447,68 @@ extra_controls = ["NHB1L"]                          # 方向てこを総括制�
 | 列車通過後・前要素解除済み | NoBook（サブ・メイン共） | 転換可 |
 
 逆方向進路（対向）は `DestinationActive` の間は発点仮予約が `is_ready_for_book_start` でブロックされます。タイマー満了（`DestinationExpired`）後は逆方向の発点でも上書き可能になります。
+
+### 6.7 開通てこ（OpeningLever）
+
+`OpeningLever` は信号を現示しない新しいてこ種別です。TOML固定方向で、指定した過走防護区間（`overrun_lock` と同じ意味の抽象軌道回路群）を「デフォルトで開通させておく」ことを宣言します。
+
+- `Signal.new()` が `SignalBase.new()` をベースにミックスインするのと同様、`OpeningLever.new()` も `NtracsObject.create_instance(SignalBase.new(), OpeningLever)` を使い、`SignalBase` の機能（`process`/`before_process` の抽象定義など）をベースにします。
+- `process()` は毎ティック、対象の各 `overrun_lock` トラックについて `Track:is_claimable_for_opening(itemName)`（空き、または既に自分自身が保持している）を確認し、成立していれば `Track:book_opening(itemName, nt)` で `bookDest` を `RouteOver` に書き込みます。`book` フィールド（メイン）には一切触れません。
+- `under_route_lock_b()` は常に `false` を返します。これにより、開通てこが保持している区間は在線解除だけでは自動的に解放されません（実信号機の本予約で明示的に上書きされるまで保持し続けます）。
+- `is_opening_lever()` は `true` を返します。これは他のオブジェクトから「このてこが開通てこかどうか」を判別するための目印メソッドです。
+
+#### 所有権の非対称性（上書きされる場合・されない場合）
+
+開通てこが `RouteOver` で保持している区間は、**その区間を実際の進路（`route_lock`/`destination`）として使う内方の信号機**には自然に上書きされますが、**その区間を過走防護区間（`overrun_lock`）として使うだけの外方の信号機**には所有権を奪われません。
+
+- **上書きされる（内方信号機が `destination` として使う場合）**：`Signal:process()` の本予約確定ブロックは `nt:get_track(self.destination):book_destination(...)` を無条件に呼び出します。`book_destination()` は `bookDest` を無条件で `DestinationActive` に書き換えるため、開通てこの `RouteOver` 予約は自然に明け渡されます。
+- **上書きされない（外方信号機が `overrun_lock` として使うだけの場合）**：4.7節で述べた安全ガード（`is_booked_temporary and not is_over_run_lock` のときのみ `book_over_run()` を呼ぶ）により、既に `is_over_run_lock` が成立している区間には `book_over_run()` を呼びません。開通てこが保持する区間に対して `is_over_run_lock` が成立するよう、`Track:is_over_run_lock()` を以下のように拡張しています。
+
+```lua
+function Track:is_over_run_lock(lever, nt)
+    local dir = nt:get_signal(lever).direction
+    if self.bookDest == BookType.RouteOver and self.destRelatedLever == lever then
+        return true
+    end
+    if self.book == BookType.RouteLock and self.direction == dir then
+        return true
+    end
+    -- 開通てこが方向一致で保持している場合も鎖錠成立とみなす
+    if self.bookDest == BookType.RouteOver and self.destDirection == dir then
+        local owner = nt:get_signal_may_nil(self.destRelatedLever)
+        if owner and type(owner.is_opening_lever) == "function" and owner:is_opening_lever() then
+            return true
+        end
+    end
+    return false
+end
+```
+
+`type(owner.is_opening_lever) == "function"` のガードは、`destRelatedLever` が偶然 `is_opening_lever` を持たないオブジェクトを指していてもエラーにしないための防御です（`Signal:setInput()` の `type(signal.setInput) == "function"` と同じパターン）。`AutoSignal` は `NtracsObject.create_instance({}, AutoSignal)` と素の `{}` をベースにしており `SignalBase` の関数を継承しないため、`is_opening_lever` を持ちません。
+
+#### `Track:book_opening()` が専用関数である理由
+
+既存の `book_over_run()` をそのまま流用すると、`destBeforeRouteLockItem` に `nt:get_signal(lever).destination` を設定しようとして `nil` になります（開通てこには `destination` フィールドが存在しないため）。`destBeforeRouteLockItem` が `nil` だと `CheckUnlockRouteLock` が `true` を返し、非在線時に毎ティック自動解放されてしまいます。そこで開通てこ専用の `book_opening()` を新設し、`destBeforeRouteLockItem` に開通てこ自身（`lever`）を設定します。`OpeningLever:under_route_lock_b()` が常に `false` を返すため、`CheckUnlockRouteLock` は常に `false` となり、実信号機に明示的に上書きされるまで保持され続けます。
+
+```lua
+function Track:book_opening(lever, nt)
+    self.bookDest = BookType.RouteOver
+    self.destRelatedLever = lever
+    self.destBeforeRouteLockItem = lever
+    self.destDirection = nt:get_signal(lever).direction
+end
+```
+
+#### TOML設定例
+
+```toml
+[XXXX_OPL]
+opening_lever = true
+direction = "right"
+overrun_lock = ["XXX1T", "XXX2T"]
+```
+
+ビルド時（`build/generate_signal.js`）に `data.opening_lever === true` のエントリは `SoyaBridge:create_opening_lever()` を呼ぶ専用コードに変換されます。`index.js` の `detectOpeningLeverConflicts()` は、複数の開通てこが同一トラックを対象区間として重複宣言していないかをビルド時に検証します。
 
 ---
 

--- a/SPEC_CORE.md
+++ b/SPEC_CORE.md
@@ -257,7 +257,7 @@ HR = ZR AND isLocked AND checkWLR AND NOT(TSSlR) AND NOT(ASR) AND isNoShort
 
 ### 4.7 過走防護フォールバック（`overrunLockFallback` / `HyR`）
 
-過走防護区間（`overrunLock`）が仮予約できない場合、通常はてこ全体の仮予約が失敗し、信号は停止現示のまま固まります。`overrunLockFallback`（TOML: `overrun_lock_fallback = true`）を有効にした信号てこに限り、過走防護区間の仮予約が失敗しても発点・進路鎖錠・着点の本予約は進行させ、代わりに警戒信号現示リレー `HyR` を true にします。現示番号（何を出すか）はコア側では決めず、`update_callback` 側で `lever.HyR` を参照して決定します（コアは `nextAspect` をクランプしません）。
+過走防護区間（`overrunLock`）が仮予約できない場合、通常はてこ全体の仮予約が失敗し、信号は停止現示のまま固まります。`overrunLockFallback`（TOML: `overrun_lock_fallback = true`）を有効にした信号てこに限り、過走防護区間の仮予約が失敗しても発点・進路鎖錠・着点の本予約は進行させます。現示番号（何を出すか）はコア側では決めず、`update_callback` 側で `lever.HyR`（警戒信号現示リレー）や `lever:isOverrunProtected(nt)` を参照して決定します（コアは `nextAspect` をクランプしません）。
 
 #### `bookTemporary` の変更点
 
@@ -297,10 +297,12 @@ end
 #### HyR（警戒信号現示リレー）
 
 ```
-HyR = HR AND NOT(isOverrunProtected)
+HyR = HR
 ```
 
-`isOverrunProtected(nt)` は `isLocked` から切り出した過走防護専用の判定で、`overrunLockFallback` を考慮せず「overrunLock 全区間が `is_over_run_lock` を満たすか」だけを返します。`HR` が成立していても過走防護が完全でない（フォールバックで通した）場合に `HyR` が true になります。
+`HyR` は実際の継電連動装置における「警戒信号現示リレー」に相当し、`HR`（より上位の階梯、いわば注意信号現示リレー相当）が成立する限り必ず true になります（HR は HyR の成立を前提として初めて成立する、というのが実物の階梯構造であり、`HR=true` かつ `HyR=false` という組み合わせは存在しません）。コア側の処理は `HyR` を true にすること以上は行いません。
+
+過走防護が完全に成立しているか（＝フォールバックで通していないか）で現示を出し分けたい `update_callback` は、`HyR` ではなく公開メソッド `lever:isOverrunProtected(nt)`（`isLocked` から切り出した過走防護専用の判定。`overrunLockFallback` を考慮せず「overrunLock 全区間が `is_over_run_lock` を満たすか」だけを返す）を直接呼び出して判定します。
 
 ### 4.8 AutoSignal
 

--- a/SPEC_CORE.md
+++ b/SPEC_CORE.md
@@ -257,7 +257,7 @@ HR = ZR AND isLocked AND checkWLR AND NOT(TSSlR) AND NOT(ASR) AND isNoShort
 
 ### 4.7 過走防護フォールバック（`overrunLockFallback` / `HyR`）
 
-過走防護区間（`overrunLock`）が仮予約できない場合、通常はてこ全体の仮予約が失敗し、信号は停止現示のまま固まります。`overrunLockFallback`（TOML: `overrun_lock_fallback = true`）を有効にした信号てこに限り、過走防護区間の仮予約が失敗しても発点・進路鎖錠・着点の本予約は進行させます。現示番号（何を出すか）はコア側では決めず、`update_callback` 側で `lever.HyR`（警戒信号現示リレー）や `lever:isOverrunProtected(nt)` を参照して決定します（コアは `nextAspect` をクランプしません）。
+過走防護区間（`overrunLock`）が仮予約できない場合、通常はてこ全体の仮予約が失敗し、信号は停止現示のまま固まります。`overrunLockFallback`（TOML: `overrun_lock_fallback = true`）を有効にした信号てこに限り、過走防護区間の仮予約が失敗しても発点・進路鎖錠・着点の本予約は進行させます。現示番号（何を出すか）はコア側では決めず、`update_callback` 側で `lever.HR`・`lever.HyR` を参照して決定します（コアは `nextAspect` を数値としてクランプすることはせず、`HR`・`HyR` がともに false のときのみ強制的に 0 にします）。
 
 #### `bookTemporary` の変更点
 
@@ -274,9 +274,11 @@ HR = ZR AND isLocked AND checkWLR AND NOT(TSSlR) AND NOT(ASR) AND isNoShort
 
 `overrunLockFallback` が有効でも `overrunReady` が false の場合、過走防護区間の `book_temporary()` 呼び出しは一切行いません。これにより、他進路や開通てこ（6.7節参照）がその区間を引き続き利用できます。
 
-#### `isBookedTemporary` / `isLocked` の変更点
+#### `isBookedTemporary` の変更点
 
-`overrunLockFallback` が true の信号は、`isBookedTemporary`・`isLocked` の両方で過走防護区間の成否チェックをスキップし、常に成立したものとして扱います（発点・routeLock・着点の判定は従来通り必須）。
+`overrunLockFallback` が true の信号は、`isBookedTemporary` で過走防護区間の成否チェックをスキップし、常に成立したものとして扱います（発点・routeLock・着点の判定は従来通り必須）。これにより、過走防護区間の仮予約が成立していなくても本予約への格上げ（発点・進路鎖錠・着点）が進みます。
+
+一方、`isLocked`（`HR` の判定に使われる）は `overrunLockFallback` の有無に関わらず一切変更していません。`isLocked` は内部で `isRouteLocked`（発点・進路鎖錠・着点のみ）と `isOverrunProtected`（過走防護区間のみ）の論理積として再構成しましたが、意味的には元の実装と完全に同一です。
 
 #### 本予約確定時の安全ガード
 
@@ -294,15 +296,34 @@ end
 - `is_booked_temporary`：自分が確かにその区間を仮予約できている場合のみ本予約に格上げする（フォールバックで見送った区間は対象外）。
 - `not is_over_run_lock`：既に（開通てこ経由などで）保護が成立している区間は、所有権を奪って `book_over_run()` を呼び直さない（6.7節参照）。
 
-#### HyR（警戒信号現示リレー）
+#### HR / HyR（信号扛上リレー / 警戒信号現示リレー）
+
+`HR` は元の定義から一切緩めていません。`signal.toml` に記載された `overrunLock` の全区間が予約できている場合にのみ true になります（`overrunLockFallback` の有無に関わらず同一の判定です）。
+
+`HyR`（警戒信号現示リレー）は次のように定義される、`HR` とは独立した新設のリレーです。
 
 ```
-HyR = HR
+baseOk = ZR AND checkWLR AND (NOT TSSlR) AND (NOT ASR) AND isNoShort   -- 過走防護の成否を含まない共通条件
+HR     = baseOk AND isLocked(nt)                                       -- isLocked = isRouteLocked AND isOverrunProtected(元の定義のまま)
+HyR    = HR OR (baseOk AND overrunLockFallback AND isRouteLocked(nt))
 ```
 
-`HyR` は実際の継電連動装置における「警戒信号現示リレー」に相当し、`HR`（より上位の階梯、いわば注意信号現示リレー相当）が成立する限り必ず true になります（HR は HyR の成立を前提として初めて成立する、というのが実物の階梯構造であり、`HR=true` かつ `HyR=false` という組み合わせは存在しません）。コア側の処理は `HyR` を true にすること以上は行いません。
+`HR` が成立していれば `HyR` は論理和の左辺により必ず true になります（`HR=true` かつ `HyR=false` という組み合わせは構造的に存在しません）。加えて、`overrunLockFallback` が有効な信号てこに限り、過走防護区間が予約できていなくても、進路鎖錠（発点・進路鎖錠・着点、`isRouteLocked`）さえ成立していれば `HyR` が true になります。
 
-過走防護が完全に成立しているか（＝フォールバックで通していないか）で現示を出し分けたい `update_callback` は、`HyR` ではなく公開メソッド `lever:isOverrunProtected(nt)`（`isLocked` から切り出した過走防護専用の判定。`overrunLockFallback` を考慮せず「overrunLock 全区間が `is_over_run_lock` を満たすか」だけを返す）を直接呼び出して判定します。
+コア側の処理は `HyR` を上記の通り計算すること以上は行いません（`nextAspect` を数値としてクランプすることはしません）。ただし最終的な強制停止条件は `HR` 単独ではなく `HR OR HyR` に変更されています。
+
+```lua
+self.nextAspect = self:updateCallback(nt, deltaTick)
+if not (self.HR or self.HyR) then
+    self.nextAspect = 0
+end
+```
+
+`update_callback` は `lever.HR`・`lever.HyR` の両方を参照して現示番号を自分で決定します。典型的な書き方は次の通りです。
+
+```lua
+update_callback = 'function(lever, nt, dt) if lever.HR then return 4 elseif lever.HyR then return 1 else return 0 end end'
+```
 
 ### 4.8 AutoSignal
 

--- a/build/generate_signal.js
+++ b/build/generate_signal.js
@@ -7,7 +7,7 @@ function generateSignal(obj) {
     out.push('local u = require("res.utils")');
     out.push("---@param s SoyaBridge");
     out.push("return function(s)");
-    out.push("local cas,cs,sr=s.create_auto_signal,s.create_signal,SwitchRoute.new");
+    out.push("local cas,cs,sr,col=s.create_auto_signal,s.create_signal,SwitchRoute.new,s.create_opening_lever");
 
     Object.entries(obj).forEach(([name, data]) => {
         out.push(leverLuaCode(name, data, controlsMap[name] || []));
@@ -18,10 +18,22 @@ function generateSignal(obj) {
 }
 
 function leverLuaCode(name, data, controls) {
+    if (data.opening_lever === true) {
+        return openingLeverLuaCode(name, data);
+    }
     if (data.auto === true) {
         return autoLeverLuaCode(name, data);
     }
     return absoluteLeverLuaCode(name, data, controls);
+}
+
+function openingLeverLuaCode(name, data) {
+    const overrunLockMake = (data.overrun_lock || []).map((v) => `"${v}"`);
+    return "col(s," +
+        `"${name}",` +
+        `RouteDirection.${capitalize(data.direction)},` +
+        `{${overrunLockMake.join(",")}}` +
+        ")";
 }
 
 function absoluteLeverLuaCode(name, data, controls) {
@@ -49,6 +61,7 @@ function absoluteLeverLuaCode(name, data, controls) {
         `{${approachTrackMake.join(",")}},` +
         `${data.approach_lock_time},` +
         `${data.overrun_lock_time},` +
+        `${data.overrun_lock_fallback === true},` +
         `{${controlsMake.join(",")}},` +
         `${data.update_callback}` +
         ")";

--- a/index.js
+++ b/index.js
@@ -55,6 +55,24 @@ function checkCrossReferences(signalObj, areaTrackObj) {
     }
 }
 
+function detectOpeningLeverConflicts(signalObj) {
+    const owner = {};
+    const errors = [];
+    Object.entries(signalObj).forEach(([name, data]) => {
+        if (data.opening_lever !== true) return;
+        (data.overrun_lock || []).forEach((track) => {
+            if (owner[track]) {
+                errors.push(`開通てこの対象区間が重複しています: '${track}' は '${owner[track]}' と '${name}' の両方に指定されています`);
+            } else {
+                owner[track] = name;
+            }
+        });
+    });
+    if (errors.length > 0) {
+        throw new Error(errors.join("\n"));
+    }
+}
+
 async function main() {
     const [signalSrc, areaTrackSrc] = await Promise.all([
         fs.promises.readFile("res/signal.toml",     "utf8"),
@@ -62,6 +80,7 @@ async function main() {
     ]);
     const signalObj = toml.parse(signalSrc);
     checkCrossReferences(signalObj, JSON.parse(areaTrackSrc));
+    detectOpeningLeverConflicts(signalObj);
 
     if (isStale("res/signal.lua", "res/signal.toml")) {
         detectControlsCycle(buildControlsMap(signalObj));

--- a/res/signal.toml
+++ b/res/signal.toml
@@ -930,13 +930,15 @@ update_callback = 'u.StandardAspectCallback_2nd(1)'
 #
 # 要件A: 過走防護フォールバック
 # 既存の信号てこテーブルに overrun_lock_fallback = true を追加すると、overrun_lock 区間の
-# 仮予約が失敗しても発点・進路鎖錠・着点の本予約は進み、HyR(警戒信号現示リレー)が true になります。
-# 現示番号は update_callback 側で lever.HyR を見て自分で決めます。
+# 仮予約が失敗しても発点・進路鎖錠・着点の本予約は進みます。HyR(警戒信号現示リレー)はHRが
+# 成立する限り常にtrueになる(HR=trueかつHyR=falseという組み合わせは存在しない)ため、
+# 「過走防護が完全に成立しているか」で現示を出し分けたい場合はHyRではなく
+# lever:isOverrunProtected(nt) を直接呼び出します。
 #
 # [SNH13R]
 # ...(既存フィールドは省略)...
 # overrun_lock_fallback = true
-# update_callback = 'function(lever, nt, dt) if lever.HyR then return 1 else return u.StandardAspectCallback_2nd(4) end end'
+# update_callback = 'function(lever, nt, dt) if lever:isOverrunProtected(nt) then return u.StandardAspectCallback_2nd(4) else return 1 end end'
 #
 # 要件B: 開通てこ
 # 信号を現示しない新しい種別のてこです。TOML固定方向で過走防護区間をデフォルト開通させておきます。

--- a/res/signal.toml
+++ b/res/signal.toml
@@ -930,15 +930,16 @@ update_callback = 'u.StandardAspectCallback_2nd(1)'
 #
 # 要件A: 過走防護フォールバック
 # 既存の信号てこテーブルに overrun_lock_fallback = true を追加すると、overrun_lock 区間の
-# 仮予約が失敗しても発点・進路鎖錠・着点の本予約は進みます。HyR(警戒信号現示リレー)はHRが
-# 成立する限り常にtrueになる(HR=trueかつHyR=falseという組み合わせは存在しない)ため、
-# 「過走防護が完全に成立しているか」で現示を出し分けたい場合はHyRではなく
-# lever:isOverrunProtected(nt) を直接呼び出します。
+# 仮予約が失敗しても発点・進路鎖錠・着点の本予約は進みます。HR は signal.toml に記載された
+# overrun_lock の全区間が予約できている場合にのみtrueになり(緩められません)、HyR(警戒信号
+# 現示リレー)は HR が成立していれば常にtrueになる(HR=trueかつHyR=falseという組み合わせは
+# 存在しない)のに加え、overrun_lock_fallback を有効にした信号てこに限り、過走防護区間が
+# 予約できていなくても進路鎖錠(発点・進路鎖錠・着点)さえ成立していればtrueになります。
 #
 # [SNH13R]
 # ...(既存フィールドは省略)...
 # overrun_lock_fallback = true
-# update_callback = 'function(lever, nt, dt) if lever:isOverrunProtected(nt) then return u.StandardAspectCallback_2nd(4) else return 1 end end'
+# update_callback = 'function(lever, nt, dt) if lever.HR then return u.StandardAspectCallback_2nd(4) elseif lever.HyR then return 1 else return 0 end end'
 #
 # 要件B: 開通てこ
 # 信号を現示しない新しい種別のてこです。TOML固定方向で過走防護区間をデフォルト開通させておきます。

--- a/res/signal.toml
+++ b/res/signal.toml
@@ -925,3 +925,25 @@ approach_track = ["SNH4LT"]
 approach_lock_time = 15
 
 update_callback = 'u.StandardAspectCallback_2nd(1)'
+
+### 使用例(参考。実際にビルドされる設定ではありません) ###
+#
+# 要件A: 過走防護フォールバック
+# 既存の信号てこテーブルに overrun_lock_fallback = true を追加すると、overrun_lock 区間の
+# 仮予約が失敗しても発点・進路鎖錠・着点の本予約は進み、HyR(警戒信号現示リレー)が true になります。
+# 現示番号は update_callback 側で lever.HyR を見て自分で決めます。
+#
+# [SNH13R]
+# ...(既存フィールドは省略)...
+# overrun_lock_fallback = true
+# update_callback = 'function(lever, nt, dt) if lever.HyR then return 1 else return u.StandardAspectCallback_2nd(4) end end'
+#
+# 要件B: 開通てこ
+# 信号を現示しない新しい種別のてこです。TOML固定方向で過走防護区間をデフォルト開通させておきます。
+# route_lock/destination として実際にその区間を使う信号機には自然に明け渡されますが、
+# overrun_lock としてのみ使う信号機には所有権を奪われません。
+#
+# [XXXX_OPL]
+# opening_lever = true
+# direction = "right"
+# overrun_lock = ["XXX1T", "XXX2T"]

--- a/src/n_tracs_core/ntracs.lua
+++ b/src/n_tracs_core/ntracs.lua
@@ -1,6 +1,7 @@
 local NtracsObject = require("src.n_tracs_core.n_tracs_object")
 local Signal = require("src.n_tracs_core.signal.signal")
 local TrafficDirectionLever = require("src.n_tracs_core.signal.traffic_direction_lever")
+local OpeningLever = require("src.n_tracs_core.signal.opening_lever")
 local Track = require("src.n_tracs_core.track.track")
 local AutoSignal = require("src.n_tracs_core.signal.auto_signal")
 local Switch = require("src.n_tracs_core.switch.switch")
@@ -81,10 +82,11 @@ function Ntracs:get_switch_may_nil(switch_id)
 end
 
 function Ntracs:create_signal(signal_id, startTrack, destination, switches, routeLock, overrunLock,
-                              signalTrack, direction, approachTrack, lockTime, overrunTime, controls, updateCallback)
+                              signalTrack, direction, approachTrack, lockTime, overrunTime, overrunLockFallback,
+                              controls, updateCallback)
     if self.signal[signal_id] then error(signal_id .. " is defined") end
     self.signal[signal_id] = Signal.new(signal_id, startTrack, destination, switches, routeLock, overrunLock,
-        signalTrack, direction, approachTrack, lockTime, overrunTime, controls, updateCallback)
+        signalTrack, direction, approachTrack, lockTime, overrunTime, overrunLockFallback, controls, updateCallback)
 end
 
 ---@param switches SwitchRoute[]
@@ -100,6 +102,14 @@ end
 function Ntracs:create_traffic_direction_lever(signal_id, my_direction, my_switch_id, another_switch_id)
     if self.signal[signal_id] then error(signal_id .. " is defined") end
     self.signal[signal_id] = TrafficDirectionLever.new(signal_id, my_direction, my_switch_id, another_switch_id)
+end
+
+---@param signal_id string
+---@param direction RouteDirection 既定の開通方向
+---@param overrunLock string[] 開通(過走防護)を既定で認める対象区間
+function Ntracs:create_opening_lever(signal_id, direction, overrunLock)
+    if self.signal[signal_id] then error(signal_id .. " is defined") end
+    self.signal[signal_id] = OpeningLever.new(signal_id, direction, overrunLock)
 end
 
 ---@param track_id string

--- a/src/n_tracs_core/signal/opening_lever.lua
+++ b/src/n_tracs_core/signal/opening_lever.lua
@@ -1,0 +1,55 @@
+-- N-TRACS Core [Opening Lever] 開通てこ
+-- 信号を現示せず、過走防護区間のデフォルト開通方向をTOML固定であらかじめ宣言します。
+-- 実際にこの区間を進路(route_lock/destination)として使う信号機の本予約によって自然に明け渡されますが、
+-- この区間を過走防護区間(overrun_lock)として使うだけの信号機には、所有権を奪われません
+-- (Track:is_over_run_lockの拡張により、方向一致だけで保護成立とみなされるため)。
+
+local NtracsObject = require("src.n_tracs_core.n_tracs_object")
+local SignalBase = require("src.n_tracs_core.signal.signal_base")
+
+---@class OpeningLever:SignalBase
+---@field direction RouteDirection
+---@field private overrunLock string[]
+local OpeningLever = {}
+
+---@param itemName string てこ名称
+---@param direction RouteDirection 既定で開通させる方向
+---@param overrunLock string[] 開通方向を宣言する対象の抽象軌道回路
+---@return OpeningLever
+function OpeningLever.new(itemName, direction, overrunLock)
+    local obj = NtracsObject.create_instance(SignalBase.new(), OpeningLever)
+    obj.name = "OpeningLever"
+    obj.itemName = itemName
+    obj.direction = direction
+    obj.overrunLock = overrunLock
+    return obj
+end
+
+---毎ループごとに呼び出してください
+---@param deltaTick number
+---@param nt Ntracs
+function OpeningLever:process(deltaTick, nt)
+    for _, trackName in ipairs(self.overrunLock) do
+        local track = nt:get_track(trackName)
+        if track:is_claimable_for_opening(self.itemName) then
+            track:book_opening(self.itemName, nt)
+        end
+    end
+end
+
+function OpeningLever:before_process()
+end
+
+---進路鎖錠が成立していたらfalseを返します(開通てこは在線解除だけでは自動解放しないため常にfalse)
+---@return boolean
+function OpeningLever:under_route_lock_b()
+    return false
+end
+
+---このてこが開通てこであることを示します
+---@return boolean
+function OpeningLever:is_opening_lever()
+    return true
+end
+
+return OpeningLever

--- a/src/n_tracs_core/signal/signal.lua
+++ b/src/n_tracs_core/signal/signal.lua
@@ -23,7 +23,7 @@ local SwitchRoute = require("src.n_tracs_core.signal.switch_route")
 ---@field lockTime number [CONSTANT]接近・保留鎖錠の時間(Tick)
 ---@field overrunTime number [CONSTANT]過走防護鎖錠の時間(Tick)
 ---@field private overrunLockFallback boolean 過走防護区間の仮予約に失敗しても本予約を進めるフラグ(TOML opt-in)
----@field HyR boolean 警戒信号現示リレー。HRがtrueかつ過走防護が完全には成立していない(フォールバックで通した)場合にtrue
+---@field HyR boolean 警戒信号現示リレー。HRより下位の階梯にあたり、HRがtrueの間は常にtrue(HR=falseならfalse)
 ---@field aspect number
 local Signal = {}
 
@@ -153,7 +153,10 @@ function Signal:process(deltaTick, nt)
         (not self.ASR) and
         self:isNoShort(nt)
 
-    self.HyR = self.HR and (not self:isOverrunProtected(nt))
+    -- HyR(警戒信号現示リレー)はHRが成立する限り必ずtrueとなる(HRはHyRより上位の階梯であるため)。
+    -- 過走防護が完全に成立しているか否かで現示を出し分けたいupdate_callbackは、
+    -- lever:isOverrunProtected(nt)を直接参照すること。
+    self.HyR = self.HR
 
     self.nextAspect = self:updateCallback(nt, deltaTick)
     if not self.HR then
@@ -292,8 +295,10 @@ function Signal:isEnterRoute(nt)
     end
 end
 
----過走防護区間が完全に鎖錠できているか確認します(開通テコ経由の保護を含みます)
----@private
+---過走防護区間が完全に鎖錠できているか確認します(開通テコ経由の保護を含みます)。
+---overrun_lock_fallbackを使う信号のupdate_callbackから、HyRだけでは区別できない
+---「過走防護が完全に成立しているか(=フォールバックで通していないか)」を判定したい場合に、
+---lever:isOverrunProtected(nt)として直接呼び出してよい公開メソッドです。
 ---@param nt Ntracs
 ---@return boolean
 function Signal:isOverrunProtected(nt)

--- a/src/n_tracs_core/signal/signal.lua
+++ b/src/n_tracs_core/signal/signal.lua
@@ -22,6 +22,8 @@ local SwitchRoute = require("src.n_tracs_core.signal.switch_route")
 ---@field private controls string[]
 ---@field lockTime number [CONSTANT]接近・保留鎖錠の時間(Tick)
 ---@field overrunTime number [CONSTANT]過走防護鎖錠の時間(Tick)
+---@field private overrunLockFallback boolean 過走防護区間の仮予約に失敗しても本予約を進めるフラグ(TOML opt-in)
+---@field HyR boolean 警戒信号現示リレー。HRがtrueかつ過走防護が完全には成立していない(フォールバックで通した)場合にtrue
 ---@field aspect number
 local Signal = {}
 
@@ -37,11 +39,12 @@ local Signal = {}
 ---@param approachTrack string[] 接近鎖錠を行う抽象軌道回路。保留鎖錠の場合は空テーブル
 ---@param lockTime number 接近・保留鎖錠の時間(Tick)
 ---@param overrunTime number 過走防護鎖錠の時間(Tick)
+---@param overrunLockFallback boolean 過走防護区間が仮予約できなくても本予約を進めるか
 ---@param controls string[]|nil このてこが総括制御するてこ名一覧
 ---@param updateCallback fun(lever: Signal, nt: Ntracs, deltaTick: number):number 信号現示コールバック。新しい信号現示(>=0, 0は停止)を返す関数です
 ---@return Signal
 function Signal.new(itemName, startTrack, destination, switches, routeLock, overrunLock,
-                    signalTrack, direction, approachTrack, lockTime, overrunTime, controls, updateCallback)
+                    signalTrack, direction, approachTrack, lockTime, overrunTime, overrunLockFallback, controls, updateCallback)
     local obj = NtracsObject.create_instance(SignalBase.new(), Signal)
     obj.name = "Lever"
     obj.itemName = itemName
@@ -64,6 +67,8 @@ function Signal.new(itemName, startTrack, destination, switches, routeLock, over
     obj.direction = direction
     obj.lockTime = lockTime
     obj.overrunTime = overrunTime
+    obj.overrunLockFallback = overrunLockFallback
+    obj.HyR = false
     obj.updateCallback = updateCallback
     obj.auto_reset = true
     return obj
@@ -133,7 +138,10 @@ function Signal:process(deltaTick, nt)
         end
         nt:get_track(self.destination):book_destination(self.itemName, routeLockBefore, nt)
         for _, track in ipairs(self.overrunLock) do
-            nt:get_track(track):book_over_run(self.itemName, nt)
+            local t = nt:get_track(track)
+            if t:is_booked_temporary(self.itemName, nt) and not t:is_over_run_lock(self.itemName, nt) then
+                t:book_over_run(self.itemName, nt)
+            end
         end
     end
 
@@ -144,6 +152,8 @@ function Signal:process(deltaTick, nt)
         (not self.TSSlR) and
         (not self.ASR) and
         self:isNoShort(nt)
+
+    self.HyR = self.HR and (not self:isOverrunProtected(nt))
 
     self.nextAspect = self:updateCallback(nt, deltaTick)
     if not self.HR then
@@ -180,6 +190,9 @@ function Signal:isBookedTemporary(nt)
     if not nt:get_track(self.destination):is_booked_temporary(self.itemName, nt) then
         return false
     end
+    if self.overrunLockFallback then
+        return true
+    end
     for _, value in ipairs(self.overrunLock) do
         if not nt:get_track(value):is_booked_temporary(self.itemName, nt) then
             return false
@@ -204,10 +217,16 @@ function Signal:bookTemporary(nt)
     if not nt:get_track(self.destination):is_ready_for_book_temporary(self.itemName, nt) then
         return
     end
+
+    local overrunReady = true
     for _, value in ipairs(self.overrunLock) do
         if not nt:get_track(value):is_ready_for_book_temporary(self.itemName, nt) then
-            return
+            overrunReady = false
+            break
         end
+    end
+    if (not overrunReady) and (not self.overrunLockFallback) then
+        return
     end
 
     if self.startTrack then nt:get_track(self.startTrack):book_start_temporary(self.itemName, nt) end
@@ -215,8 +234,10 @@ function Signal:bookTemporary(nt)
         nt:get_track(value):book_temporary(self.itemName, nt)
     end
     nt:get_track(self.destination):book_temporary(self.itemName, nt)
-    for _, value in ipairs(self.overrunLock) do
-        nt:get_track(value):book_temporary(self.itemName, nt)
+    if overrunReady then
+        for _, value in ipairs(self.overrunLock) do
+            nt:get_track(value):book_temporary(self.itemName, nt)
+        end
     end
 end
 
@@ -271,6 +292,19 @@ function Signal:isEnterRoute(nt)
     end
 end
 
+---過走防護区間が完全に鎖錠できているか確認します(開通テコ経由の保護を含みます)
+---@private
+---@param nt Ntracs
+---@return boolean
+function Signal:isOverrunProtected(nt)
+    for _, value in ipairs(self.overrunLock) do
+        if not nt:get_track(value):is_over_run_lock(self.itemName, nt) then
+            return false
+        end
+    end
+    return true
+end
+
 ---進路鎖錠と過走防護区間をロックできたか確認します
 ---@private
 ---@param nt Ntracs
@@ -287,12 +321,7 @@ function Signal:isLocked(nt)
     if not nt:get_track(self.destination):is_destination_locked(self.itemName) then
         return false
     end
-    for _, value in ipairs(self.overrunLock) do
-        if not nt:get_track(value):is_over_run_lock(self.itemName, nt) then
-            return false
-        end
-    end
-    return true
+    return self:isOverrunProtected(nt) or self.overrunLockFallback
 end
 
 ---すべての転轍機が鎖錠できたか確認します

--- a/src/n_tracs_core/signal/signal.lua
+++ b/src/n_tracs_core/signal/signal.lua
@@ -23,7 +23,8 @@ local SwitchRoute = require("src.n_tracs_core.signal.switch_route")
 ---@field lockTime number [CONSTANT]接近・保留鎖錠の時間(Tick)
 ---@field overrunTime number [CONSTANT]過走防護鎖錠の時間(Tick)
 ---@field private overrunLockFallback boolean 過走防護区間の仮予約に失敗しても本予約を進めるフラグ(TOML opt-in)
----@field HyR boolean 警戒信号現示リレー。HRより下位の階梯にあたり、HRがtrueの間は常にtrue(HR=falseならfalse)
+---@field HyR boolean 警戒信号現示リレー。HRがtrueの間は常にtrue。加えてoverrunLockFallbackが有効な信号は、
+---過走防護区間が予約できていなくても進路鎖錠(発点・進路鎖錠・着点)が成立していればtrueになる
 ---@field aspect number
 local Signal = {}
 
@@ -145,21 +146,28 @@ function Signal:process(deltaTick, nt)
         end
     end
 
-    self.HR =
+    -- HRの成立に必要な、過走防護区間の成否を除いた共通条件(進路鎖錠に関わらない部分)
+    local baseOk =
         ZR and
-        self:isLocked(nt) and
         self:checkWLR(nt) and
         (not self.TSSlR) and
         (not self.ASR) and
         self:isNoShort(nt)
 
-    -- HyR(警戒信号現示リレー)はHRが成立する限り必ずtrueとなる(HRはHyRより上位の階梯であるため)。
-    -- 過走防護が完全に成立しているか否かで現示を出し分けたいupdate_callbackは、
-    -- lever:isOverrunProtected(nt)を直接参照すること。
-    self.HyR = self.HR
+    -- HR(信号扛上リレー)は、signal.tomlに記載された過走防護区間(overrunLock)が
+    -- 全て予約できている場合にのみtrueになる(overrunLockFallbackの有無に関わらず、
+    -- 元のisLockedの定義から一切緩めない)。
+    self.HR = baseOk and self:isLocked(nt)
+
+    -- HyR(警戒信号現示リレー)は、HRが成立していれば常にtrue。加えて、overrunLockFallbackが
+    -- 有効な信号てこに限り、過走防護区間が予約できていなくても進路鎖錠(発点・進路鎖錠・着点)さえ
+    -- 成立していればtrueになる。
+    self.HyR =
+        self.HR or
+        (baseOk and self.overrunLockFallback and self:isRouteLocked(nt))
 
     self.nextAspect = self:updateCallback(nt, deltaTick)
-    if not self.HR then
+    if not (self.HR or self.HyR) then
         self.nextAspect = 0
     end
 end
@@ -295,26 +303,11 @@ function Signal:isEnterRoute(nt)
     end
 end
 
----過走防護区間が完全に鎖錠できているか確認します(開通テコ経由の保護を含みます)。
----overrun_lock_fallbackを使う信号のupdate_callbackから、HyRだけでは区別できない
----「過走防護が完全に成立しているか(=フォールバックで通していないか)」を判定したい場合に、
----lever:isOverrunProtected(nt)として直接呼び出してよい公開メソッドです。
----@param nt Ntracs
----@return boolean
-function Signal:isOverrunProtected(nt)
-    for _, value in ipairs(self.overrunLock) do
-        if not nt:get_track(value):is_over_run_lock(self.itemName, nt) then
-            return false
-        end
-    end
-    return true
-end
-
----進路鎖錠と過走防護区間をロックできたか確認します
+---発点・進路鎖錠・着点が鎖錠できているか確認します(過走防護区間は含みません)
 ---@private
 ---@param nt Ntracs
 ---@return boolean
-function Signal:isLocked(nt)
+function Signal:isRouteLocked(nt)
     if not nt:get_track(self.startTrack):is_start_locked(self.itemName, nt) then
         return false
     end
@@ -326,7 +319,30 @@ function Signal:isLocked(nt)
     if not nt:get_track(self.destination):is_destination_locked(self.itemName) then
         return false
     end
-    return self:isOverrunProtected(nt) or self.overrunLockFallback
+    return true
+end
+
+---過走防護区間が完全に鎖錠できているか確認します(開通テコ経由の保護を含みます)
+---@private
+---@param nt Ntracs
+---@return boolean
+function Signal:isOverrunProtected(nt)
+    for _, value in ipairs(self.overrunLock) do
+        if not nt:get_track(value):is_over_run_lock(self.itemName, nt) then
+            return false
+        end
+    end
+    return true
+end
+
+---進路鎖錠と過走防護区間をロックできたか確認します。overrunLockFallbackの有無に関わらず、
+---過走防護区間(overrunLock)が全て予約できている場合にのみtrueになります
+---(フォールバックによる緩和はHyR側でのみ行われ、isLocked/HRはここでは緩めません)。
+---@private
+---@param nt Ntracs
+---@return boolean
+function Signal:isLocked(nt)
+    return self:isRouteLocked(nt) and self:isOverrunProtected(nt)
 end
 
 ---すべての転轍機が鎖錠できたか確認します

--- a/src/n_tracs_core/track/track.lua
+++ b/src/n_tracs_core/track/track.lua
@@ -167,8 +167,43 @@ end
 ---@return boolean
 function Track:is_over_run_lock(lever, nt)
     local dir = nt:get_signal(lever).direction
-    return (self.bookDest == BookType.RouteOver and self.destRelatedLever == lever)
-        or (self.book == BookType.RouteLock and self.direction == dir)
+    if self.bookDest == BookType.RouteOver and self.destRelatedLever == lever then
+        return true
+    end
+    if self.book == BookType.RouteLock and self.direction == dir then
+        return true
+    end
+    if self.bookDest == BookType.RouteOver and self.destDirection == dir then
+        local owner = nt:get_signal_may_nil(self.destRelatedLever)
+        if owner and type(owner.is_opening_lever) == "function" and owner:is_opening_lever() then
+            return true
+        end
+    end
+    return false
+end
+
+---開通てこが当該区間を(再)宣言できる状態か確認します。空き、または既に自分自身が保持している場合のみtrueです。
+---@param lever string
+---@return boolean
+function Track:is_claimable_for_opening(lever)
+    return self.bookDest == BookType.NoBook
+        or (self.bookDest == BookType.RouteOver and self.destRelatedLever == lever)
+end
+
+---開通てこによる過走防護方向の予約(bookDestのみ変更)。
+---destBeforeRouteLockItemに開通てこ自身(lever)を設定することで、under_route_lock_b()が常にfalseを返す
+---開通てこの性質を利用し、在線解除だけでは自動的に解放されないようにします(実信号機の本予約で明示的に
+---book_over_run()が呼ばれるまで保持し続けます)。既存のbook_over_run()をそのまま流用すると
+---destBeforeRouteLockItemがnt:get_signal(lever).destinationを参照しようとしてnilになり
+---(開通てこにはdestinationフィールドが存在しないため)、非在線時に毎ティック自動解放されてしまうため、
+---専用の関数として新設しています。
+---@param lever string
+---@param nt Ntracs
+function Track:book_opening(lever, nt)
+    self.bookDest = BookType.RouteOver
+    self.destRelatedLever = lever
+    self.destBeforeRouteLockItem = lever
+    self.destDirection = nt:get_signal(lever).direction
 end
 
 ---@param lever string

--- a/src/n_tracs_soyabridge/soya_bridge.lua
+++ b/src/n_tracs_soyabridge/soya_bridge.lua
@@ -66,12 +66,13 @@ end
 ---@param approachTrack string[] 接近鎖錠を行う抽象軌道回路。保留鎖錠の場合は空テーブル
 ---@param lockTime number 接近・保留鎖錠の時間(sec)
 ---@param overrunTime number 過走防護鎖錠の時間(sec)
+---@param overrunLockFallback boolean 過走防護区間が仮予約できなくても本予約を進めるか
 ---@param controls string[]|nil このてこが総括制御するてこ名一覧
 ---@param updateCallback fun(lever: Signal, nt: Ntracs, deltaTick: number):number 信号現示コールバック。新しい信号現示(>=0, 0は停止)を返す関数です
 function SoyaBridge:create_signal(name, startTrack, destination, switches, routeLock, overrunLock, signalTrack, direction,
-                                  approachTrack, lockTime, overrunTime, controls, updateCallback)
+                                  approachTrack, lockTime, overrunTime, overrunLockFallback, controls, updateCallback)
     self.nt:create_signal(name, startTrack, destination, switches, routeLock, overrunLock, signalTrack,
-        direction, approachTrack, lockTime * 60, overrunTime * 60, controls, updateCallback)
+        direction, approachTrack, lockTime * 60, overrunTime * 60, overrunLockFallback, controls, updateCallback)
 end
 
 ---@param name string てこ名称
@@ -88,6 +89,13 @@ end
 ---@param anotherSwitchName string 相手端の仮想方向スイッチ名
 function SoyaBridge:create_traffic_direction_lever(name, myDirection, mySwitchName, anotherSwitchName)
     self.nt:create_traffic_direction_lever(name, myDirection, mySwitchName, anotherSwitchName)
+end
+
+---@param name string
+---@param direction RouteDirection 既定の開通方向
+---@param overrunLock string[] 開通(過走防護)を既定で認める対象区間
+function SoyaBridge:create_opening_lever(name, direction, overrunLock)
+    self.nt:create_opening_lever(name, direction, overrunLock)
 end
 
 ---@param name string


### PR DESCRIPTION
## Summary

- 過走防護区間(`overrun_lock`)が仮予約できない場合でも、`signal.toml`で明示的に`overrun_lock_fallback = true`とオプトインした信号てこに限り、本予約(発点・進路鎖錠・着点)を進行させ、警戒信号現示リレー`HyR`を立てる機能を追加。現示番号自体は引き続き`update_callback`側の判断に委ね、コア側でのクランプは行わない。
- 信号を現示しない新しいてこ`OpeningLever`(開通てこ)を追加。TOML固定方向で過走防護区間をデフォルト開通させておき、実際にその区間を進路(`route_lock`/`destination`)として使う内方の信号機には自然に明け渡される一方、その区間を`overrun_lock`としてのみ使う外方の信号機には所有権を奪われない(`Track:is_over_run_lock`の拡張 + `Signal:process`側の安全ガードで実現)。
- `build/generate_signal.js`・`index.js`でTOMLの`overrun_lock_fallback`/`opening_lever`をLuaコード生成に配線し、開通てこ同士の対象区間重複をビルド時に検出するチェックを追加。
- `SPEC_CORE.md`・`res/signal.toml`に仕様とTOML記述例を追記。

## Test plan

- [x] 変更した全`.lua`ファイルの構文チェック(`lua -e "assert(loadfile(...))"`)
- [x] `npm run build`で既存`res/signal.toml`(新フィールド未使用)に対する完全な後方互換性を確認(Cross-reference check / Controls cycle check / Lua syntax check)
- [x] スモークテスト(過走防護フォールバックでのHR/HyR成立、開通てこの所有権が外方信号に奪われないこと、内方信号には自然に明け渡されること)を実行し、全アサーション成功を確認 — 検証コードと実行結果は別コメントに記載

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017A2uHcWnuyud7yyhhcBnzU

---
_Generated by [Claude Code](https://claude.ai/code/session_017A2uHcWnuyud7yyhhcBnzU)_