### PR TITLE
auto_resetがcontrols/extra_controls先のてこに伝播しない不具合を修正

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -38,6 +38,12 @@
 - **影響**: 継続進行を意図して両信号を進行にした際、後方信号（NHB2L）のてこが `true` のまま自動復位せず永久に固着する。信号現示は列車通過中ずっと停止（赤）のままで、列車が該当区間を通過し終えた後になって進行（緑）に変化することさえある。運転士は司令の意図（継続進行）に反して赤信号を現示され続けるため、安全上の混乱を招く。
 - **対応**: `is_ready_for_book_temporary()` の `mainOk` と `is_booked_temporary()` に `self.book == BookType.Start and self.direction == dir`（同一方向のみ）の許容節を追加。`book_temporary()`（`book == NoBook` のみ書き込み）・`book_destination()`（`book == Temporary` かつ同一てこのときのみ `book` をクリア）は他てこの `Start` を破壊しないため変更不要。**方向条件 `self.direction == dir` により対向進路の割り込みは従来通り排除**され、正面衝突相当の危険な同時進行は許容しない。Lua シミュレーションで両順序が同一・正常に動作すること、対向方向が正しく拒否されることを確認済み。
 
+### C-7. `auto_reset` が `self.input` を直接書き換え、総括制御(`controls`/`extra_controls`)先のてこに復位が伝播しない ✅ 修正済み
+- **ファイル**: `src/n_tracs_core/signal/signal.lua` `Signal:process()` 冒頭
+- **問題**: `auto_reset` による自動復位は `if self.auto_reset and self.TSSlR then self.input = false end` と `self.input` を直接書き換えているだけで、`controls`（`extra_controls` を含む）への伝播を行う `setInput()` を経由していなかった。`TrafficDirectionLever`（方向てこ）は `NHB2L`（`extra_controls = ["NHB1L"]`）や `HLT1R`（`extra_controls = ["HLT2R"]`）のように総括制御でのみ操作され、自身が単独で反位・定位を切り替える手段を持たない。そのため、総括元の信号てこが `auto_reset` で復位しても、方向てこ側の `input` は `true` のまま永久に固着する。
+- **影響**: 掘戸町(HLT)〜北港(NHB)間の単線区間で、`NHB2L`→`HLT1L` と進んで列車が `HLT1LT` に到着した後、`NHB2L` の総括制御下にある方向てこ `NHB1L` が固着したままになる。`NHB1L` は「出し側」動作を続けて自区間の仮想方向分岐器 `NHB_HLT_FR` を上り方向(`Reverse`)に固定し続けるため、折り返し方向の `HLT1R`（`extra_controls = ["HLT2R"]`）が `HLT2R` を反位にしても相手端の確認条件が成立せず、`HLT_NHB_FR` を `normal` に転換できない。結果として `HLT1R` 自身の転てつ器条件（`switches = [{ sw = "HLT_NHB_FR", t = "normal" }]`）が恒久的に不成立となり、`checkSwitches()` が常に `false` を返すため `ZR`・`HR` が絶対に成立せず、`HLT1R` は何度てこを反位にしても進行現示にならない。
+- **対応**: `self.input = false` を `self:setInput(false, nt)` に変更し、`auto_reset` による復位も `controls`/`extra_controls` に正しく伝播するようにした。`setInput()` 側は既存の cycle-safe な多段伝播（C-3 対応）をそのまま利用する。Lua シミュレーション（`NHB2L`/`HLT1L`/`NHB1L`/`HLT1R`/`HLT2R` 相当の最小構成）で、修正前は総括制御下の方向てこが固着して `HLT1R` の `HR` が永久に `false` のままであること、修正後は `auto_reset` 発火の翌ティックで方向てこが正しく復位し `HLT1R.HR` が `true` になることを確認済み。
+
 ---
 
 ## 高（データ整合性・状態破損）
@@ -114,6 +120,7 @@
 | C-4 | クリティカル | ✅ 修正済み |
 | C-5 | クリティカル | ✅ 修正済み |
 | C-6 | クリティカル | ✅ 修正済み |
+| C-7 | クリティカル | ✅ 修正済み |
 | H-1 | 高 | ✅ 仕様確認済み（対応不要） |
 | H-2 | 高 | ✅ 仕様確認済み（対応不要） |
 | H-3 | 高 | ✅ 仕様確認済み（対応不要） |

--- a/SPEC_CORE.md
+++ b/SPEC_CORE.md
@@ -210,7 +210,7 @@ HR = ZR AND isLocked AND checkWLR AND NOT(TSSlR) AND NOT(ASR) AND isNoShort
 3. **仮予約**（`ZR` が true かつ `bookTemporary` 成功）：発点・routeLock・着点・overrunLock をすべて `Temporary`（または発点サブ互換確認）に。全区間のチェックがアトミックで行われ、1つでも不成立なら全体をスキップ。
 4. **本予約確定**（`NOT(ASR)` かつ `isBookedTemporary` 成立）：発点→`Start`（メイン）、routeLock→`RouteLock`（メイン）、着点→`DestinationActive`（サブ）、overrunLock→`RouteOver`（サブ）に格上げ
 5. **HR扛上**（鎖錠完成・全条件成立）→ 信号進行現示
-6. **列車進入**（`isEnterRoute` が true）→ `TSSlR` が上がり、次ティックで `input = false`（自動復位）
+6. **列車進入**（`isEnterRoute` が true）→ `TSSlR` が上がり、次ティックで `setInput(false, nt)` が呼ばれ `input = false`（自動復位）。`setInput()` を経由するため、`controls`/`extra_controls` で総括制御しているてこ（方向てこ等）にも復位が伝播する。
 7. **進路解除**（列車通過後、`CheckUnlockRouteLock` 連鎖で順次 `NoBook` に）
    - 発点：Signal.ASR 扛上で即時解除（在線有無問わず）
    - routeLock：在線なし かつ 前要素解除済み

--- a/src/n_tracs_core/signal/signal.lua
+++ b/src/n_tracs_core/signal/signal.lua
@@ -80,8 +80,11 @@ end
 ---@param nt Ntracs
 function Signal:process(deltaTick, nt)
     -- 自動復位モードであり、かつ復位条件を満たす場合
+    -- setInput() を経由することで、総括制御(controls/extra_controls)先のてこ
+    -- （方向てこ等）にも復位が正しく伝播する。self.input を直接書き換えると
+    -- 伝播がスキップされ、総括制御先のてこが反位のまま固着してしまう。
     if self.auto_reset and self.TSSlR then
-        self.input = false
+        self:setInput(false, nt)
     end
 
     -- てこリレー（閉路鎖錠条件と、総括制御条件を加える必要あり）


### PR DESCRIPTION
## Summary

- `Signal:process()` の自動復位（`auto_reset`）が `self.input = false` と直接フィールドを書き換えており、`controls`/`extra_controls` への伝播を担う `setInput()` を経由していなかったため、総括制御下のてこ（方向てこ等）が自動復位後も反位のまま固着していた。
- 具体例: 掘戸町(HLT)〜北港(NHB)間の単線区間で `NHB2L`→`HLT1L` と進んで `HLT1LT` に到着した後、`NHB2L` が総括制御する方向てこ `NHB1L`（`extra_controls = ["NHB1L"]`）が固着し続け、仮想方向分岐器 `NHB_HLT_FR` が上り方向に固定され続ける。結果として折り返しの `HLT1R` が `HLT_NHB_FR` を `normal` に転換できず、`checkSwitches()` が恒久的に `false` となり `HLT1R` は何度てこを反位にしても進行現示にならない。
- `self.input = false` を `self:setInput(false, nt)` に変更し、`auto_reset` による復位も既存の多段伝播（`controls`/`extra_controls`）に正しく乗るよう修正。`ISSUES.md`（C-7として追記）と `SPEC_CORE.md` 4.3節も更新。

## Test plan

- [x] Lua シミュレーション（`NHB2L`/`HLT1L`/`NHB1L`/`HLT1R`/`HLT2R` 相当の最小構成を `src/n_tracs_core/ntracs.lua` の API で直接構築）で検証:
  - 修正前: 総括制御下の方向てこ (`LEV_A`) の `input` が `true` のまま固着し、折り返し信号 (`SIG_RETURN`) の `HR` が永久に `false`。
  - 修正後: `auto_reset` 発火の翌ティックで方向てこが正しく復位（`input = false`）し、折り返し信号の `HR` が `true` になることを確認。
- [x] `npm run build`（`Cross-reference check: OK` / `Controls cycle check: OK`、生成Luaの構文チェックは `lua53` 未導入のため環境上スキップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UtVUhyH2E8ZUVJj3eb7Uoj

---
_Generated by [Claude Code](https://claude.ai/code/session_01UtVUhyH2E8ZUVJj3eb7Uoj)_