### PR TITLE
実地テストの再現テストを書くためのひな形と一括実行ランナーを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "private": true,
   "scripts": {
-    "build": "node index.js"
+    "build": "node index.js",
+    "test:gen-res": "node tests/gen_res.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "private": true,
   "scripts": {
     "build": "node index.js",
-    "test:gen-res": "node tests/gen_res.js"
+    "test:gen-res": "node tests/gen_res.js",
+    "pretest": "npm run test:gen-res",
+    "test": "node tests/run_all.js"
   },
   "repository": {
     "type": "git",

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,73 @@
+# テストケースの書き方
+
+実地テスト（Stormworks上での実運用）で見つかったバグを、ゲームを介さずに
+Lua単体で再現・固定化するためのしくみです。ロジック層(`src/n_tracs_core`)は
+`server` などのStormworks APIに依存していないため、`lua` コマンドだけで
+本番と同じ信号・軌道回路の組み合わせを動かせます。
+
+## 準備
+
+```sh
+npm install       # toml パッケージなどdevDependenciesの取得(初回のみ)
+node tests/gen_res.js
+```
+
+`tests/gen_res.js` は `res/area_track.json` / `res/signal.toml`（実際の運用データ）
+から `res/area_track.lua` / `res/signal.lua` を生成します。中身は `npm run build`
+と同じジェネレータを使っているため本番ビルドと同一です。圧縮や `dist/` への配置は
+行わないぶん高速です。生成物なので `.gitignore` 済み・コミット不要ですが、
+`res/area_track.json` や `res/signal.toml` を編集した後は再実行してください。
+
+## 実行
+
+```sh
+lua tests/repro_template.lua
+```
+
+失敗すると `os.exit(1)` するので、そのままCIの合否判定にも使えます。
+
+## 書き方のコツ
+
+- **本番データをそのまま読み込む。** `tests/harness.lua` の `new_production_sw()` は
+  `res/area_track.lua` / `res/signal.lua` / `res/switch.lua` / `res/signal_alias.lua`
+  を script.lua と同じ順序でロードします。信号機・軌道回路の名前は本番と同じもの
+  （`NHB5R`、`NHB5RT` など）がそのまま使えるので、実地テストの状況をID単位で
+  忠実に再現できます。ただし本当に必要な範囲だけをシナリオに登場させ、
+  無関係な信号機・進路には触れないようにする（＝関与する分だけ最小化する）と、
+  assertが読みやすくなり、Claudeに渡したときの原因特定も速くなります。
+- **在線は手動で切り替える。** 実車の代わりに `short` という
+  `table<track_id, boolean>` を自分で書き換え、`h.tick(sw, short)` に渡します。
+  `SoyaBridge:before_process()` は実車のaxle位置から在線を計算するため、車両を
+  スポーンさせないテストではそのまま使えません（`test.lua` と同じ考え方です）。
+- **1回の `tick()` が1論理サイクル。** `script.lua` の `onTick` は6tickごとに
+  `before_process` → `process(6)` を1回実行する構成になっています
+  （`Phase = (Phase + 1) % 6` を参照）。`h.tick()` はこれ1回分に相当するので、
+  「6サイクルごとに在線を切り替える」＝「`h.tick()` を呼ぶたびに `short` を
+  更新する」と考えて問題ありません。
+- **assertはソフトアサートで積み上げる。** `h.new_checker()` が返す `Checker` の
+  `check(label, actual, expected)` は失敗しても止まらず記録だけして継続します。
+  1件失敗した時点で打ち切られると、後続のサイクルで状態がどう壊れていくのか
+  わからなくなるため、時系列で複数の時点を確認するテストとは相性が悪いです。
+  最後に `report()` を呼ぶと集計し、1件でも失敗していれば非0終了します。
+- **`aspect` は1サイクル遅れる。** `Signal:process()` は次の現示を `nextAspect` に
+  貯めるだけで、実際に `aspect` へ反映されるのは次の `before_process()` 時です。
+  「このサイクルでHRが扛上したのに、まだ`aspect`が0のまま」は多くの場合バグでは
+  なく仕様なので、assertを書く前に一度 `print` で実際の値の推移を確認することを
+  おすすめします。
+- **失敗する状態のまま提出してよい。** 目的はバグの固定化なので、現状のコードで
+  `check()` が `[NG]` になるテストをそのまま用意し、「このテストが通るように直して
+  ほしい」という形でClaudeに渡すのが最も伝わりやすいです。
+
+## ファイル構成
+
+- `tests/gen_res.js` — 本番データから `res/area_track.lua` / `res/signal.lua` を生成
+- `tests/harness.lua` — `new_production_sw()` / `tick()` / `new_checker()` を提供
+- `tests/repro_template.lua` — 上記を使った最小のひな形（コピーして使ってください）
+
+## 既知の注意点
+
+リポジトリ直下の `test.lua` は `WAK1R` / `WAK1RT` という信号機・軌道回路を参照して
+いますが、現在の `res/signal.toml` / `res/area_track.json` にはこれらは存在しません
+（路線データが更新され、参照先が失われたと見られます）。そのまま実行はできないため、
+新しくテストを書く際は本ディレクトリのひな形を使うか、`res/signal.toml` に実在する
+信号機名で組み立ててください。

--- a/tests/README.md
+++ b/tests/README.md
@@ -20,11 +20,35 @@ node tests/gen_res.js
 
 ## 実行
 
+1ファイルだけ実行する場合:
+
 ```sh
 lua tests/repro_template.lua
 ```
 
 失敗すると `os.exit(1)` するので、そのままCIの合否判定にも使えます。
+
+`tests/repro_*.lua` を全部まとめて実行してサマリを見たい場合:
+
+```sh
+npm test
+```
+
+`pretest` で `tests/gen_res.js` が自動実行されてから、`tests/run_all.js` が
+`tests/repro_*.lua` を1本ずつ別プロセスとして実行し、最後に
+
+```
+[PASS] tests/repro_template.lua
+[FAIL] tests/repro_xxxx.lua
+    [NG] cycle3: ... (expected=true, actual=false)
+    1 / 5 件のアサーションが失敗しました
+============================================================
+4 / 5 件のテストファイルが成功しました
+```
+
+のような一覧を表示します。失敗したファイルの `[NG]` 行だけを抜き出して表示
+するので、まとめて実行してもどこが壊れているかすぐわかります。1件でも失敗
+すれば非0終了するので、CIにもそのまま組み込めます。
 
 ## 書き方のコツ
 
@@ -63,6 +87,7 @@ lua tests/repro_template.lua
 - `tests/gen_res.js` — 本番データから `res/area_track.lua` / `res/signal.lua` を生成
 - `tests/harness.lua` — `new_production_sw()` / `tick()` / `new_checker()` を提供
 - `tests/repro_template.lua` — 上記を使った最小のひな形（コピーして使ってください）
+- `tests/run_all.js` — `tests/repro_*.lua` を一括実行してサマリを表示する（`npm test`）
 
 ## 既知の注意点
 

--- a/tests/gen_res.js
+++ b/tests/gen_res.js
@@ -1,0 +1,39 @@
+// テスト実行前に res/area_track.lua と res/signal.lua を、実際の運用データ
+// (res/area_track.json, res/signal.toml) から生成します。
+//
+// npm run build (index.js) と同じジェネレータ (build/generate_area_track.js,
+// build/generate_signal.js) を使うため、生成される内容は本番ビルドと同一です。
+// storm-lua-minify によるスクリプト圧縮や dist/ への配置、NTRACS_SW_DIR への
+// コピーは行いません。テストの実行だけが目的のためです。
+//
+// 使い方: node tests/gen_res.js  (このあと Lua 側で require("res.area_track") /
+// require("res.signal") が本番構成をロードできるようになります)
+const fs = require("fs");
+const path = require("path");
+const toml = require("toml");
+const generateAreaTrack = require("../build/generate_area_track");
+const { generateSignal, buildControlsMap, detectControlsCycle } = require("../build/generate_signal");
+
+process.chdir(path.join(__dirname, ".."));
+
+async function main() {
+    const [signalSrc, areaTrackSrc] = await Promise.all([
+        fs.promises.readFile("res/signal.toml", "utf8"),
+        fs.promises.readFile("res/area_track.json", "utf8"),
+    ]);
+
+    const signalObj = toml.parse(signalSrc);
+    detectControlsCycle(buildControlsMap(signalObj));
+
+    await Promise.all([
+        fs.promises.writeFile("res/area_track.lua", generateAreaTrack(JSON.parse(areaTrackSrc))),
+        fs.promises.writeFile("res/signal.lua", generateSignal(signalObj)),
+    ]);
+
+    console.log("Generated res/area_track.lua and res/signal.lua from production data.");
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/tests/harness.lua
+++ b/tests/harness.lua
@@ -1,0 +1,99 @@
+-- N-TRACS テスト用ハーネス
+--
+-- Stormworks実機を介さずに、本番の路線構成(res/area_track.json, res/signal.toml)を
+-- そのままロードしてロジックを検証するためのヘルパーです。
+--
+-- 事前準備: リポジトリルートで `node tests/gen_res.js` を実行し、res/area_track.lua と
+-- res/signal.lua を最新の本番データから生成してください。
+-- (両ファイルは .gitignore 対象のビルド生成物です。commit しないでください)
+--
+-- 実行方法（リポジトリルートから）: lua tests/repro_xxx.lua
+
+-- 本番(Stormworks/LifeBoatAPI)環境ではtemp.jsonが提供されますが、ローカル実行では
+-- 存在しないため、res/utils.lua 等が読み込めるようスタブを積みます。
+-- (テストでは json.stringify の出力内容自体は使わないため、ダミーで十分です)
+package.preload["temp.json"] = function()
+    return {
+        stringify = function(_) return "" end,
+        parse = function(_) return {} end,
+    }
+end
+
+local SoyaBridge = require("src.n_tracs_soyabridge.soya_bridge")
+
+local M = {}
+
+---本番構成一式(area_track, signal, switch, signal_alias)を読み込んだ SoyaBridge を作成します。
+---@return SoyaBridge
+function M.new_production_sw()
+    local sw = SoyaBridge.new()
+    require("res.area_track")(sw)
+    require("res.signal")(sw)
+    require("res.switch")(sw)
+    require("res.signal_alias")(sw)
+    return sw
+end
+
+---車両を使わず、在線状態を直接指定してテストを進めるための before_process 代替です。
+---(SoyaBridge:before_process() は実車のaxle位置から在線を算出するため、車両を
+--- スポーンさせないテストでは使えません。test.lua と同じ考え方です)
+---@param sw SoyaBridge
+---@param shortMap table<string, boolean> 在線させたい抽象軌道回路名の集合(true=在線)
+local function before_process(sw, shortMap)
+    shortMap = shortMap or {}
+    for name, v in pairs(sw.nt.track) do
+        v:before_process(shortMap[name] or false)
+    end
+    for _, v in pairs(sw.nt.switch) do
+        v:before_process(v.W ~= 0 and v.W or v.K)
+    end
+    for _, v in pairs(sw.nt.signal) do
+        v:before_process()
+    end
+end
+M.before_process = before_process
+
+---1サイクル進めます。script.lua の onTick は6tickごとに
+---before_process -> process(6) の順で1サイクルとして処理しているため、
+---本ハーネスの1回の tick() 呼び出しは実機の6tick・1サイクルに相当します。
+---@param sw SoyaBridge
+---@param shortMap table<string, boolean>
+function M.tick(sw, shortMap)
+    before_process(sw, shortMap)
+    sw:process(6)
+end
+
+---ソフトアサート用チェッカー。途中で止めず失敗をすべて記録し、最後にまとめて
+---報告します。「Nサイクル目時点の状態」を何箇所も確認したいテストに向いています。
+local Checker = {}
+Checker.__index = Checker
+
+function M.new_checker()
+    return setmetatable({ failed = 0, total = 0 }, Checker)
+end
+
+---@param label string どの時点・何を確認しているかが分かる説明
+---@param actual any
+---@param expected any
+function Checker:check(label, actual, expected)
+    self.total = self.total + 1
+    if actual ~= expected then
+        self.failed = self.failed + 1
+        print(string.format("[NG] %s (expected=%s, actual=%s)", label, tostring(expected), tostring(actual)))
+    else
+        print(string.format("[OK] %s", label))
+    end
+end
+
+---@return boolean success
+function Checker:report()
+    if self.failed > 0 then
+        print(string.format("\n%d / %d 件のアサーションが失敗しました", self.failed, self.total))
+        os.exit(1)
+    else
+        print(string.format("\n%d 件のアサーションはすべて成功しました", self.total))
+    end
+    return self.failed == 0
+end
+
+return M

--- a/tests/repro_template.lua
+++ b/tests/repro_template.lua
@@ -1,0 +1,61 @@
+-- 実地テストで判明したバグを再現するためのテストケース ひな形
+--
+-- 事前準備（初回だけ / signal.toml, area_track.json を更新した後も）:
+--   node tests/gen_res.js
+--
+-- 実行方法（リポジトリルートから）:
+--   lua tests/repro_template.lua
+--
+-- 使い方:
+--   1. このファイルをコピーして tests/repro_<issue番号や現象名>.lua を作る
+--   2. 本番の信号機/軌道回路名（NHB5R, WAK1RT など。res/signal.toml, res/area_track.json
+--      に実在する名前）を使い、バグが起きた状況を組み立てる
+--   3. 各サイクルの直後に check() で「そのときどうなっているべきか」を書く
+--      (現状のコードでは失敗する = バグを再現できている、という状態でよい)
+--   4. これをそのまま Claude への修正依頼に添付する
+
+local h = require("tests.harness")
+
+-- 本番構成一式をロードします(実際のゲーム内と同じ信号機・軌道回路・転てつ器)
+local sw = h.new_production_sw()
+local c = h.new_checker()
+
+-- 在線(車両がその抽象軌道回路上にいる)状態は、テスト側でこの table を書き換えて
+-- 明示的に指定します。実車を使わないため、この table が「今どこに車両がいるか」の
+-- 唯一の情報源になります。詳しくは tests/harness.lua の before_process を参照してください。
+local short = {}
+
+----------------------------------------------------------------
+-- スタートのtick: てこを操作してから最初の1サイクルを進めます
+----------------------------------------------------------------
+sw.nt:get_signal("NHB5R"):setInput(true)
+h.tick(sw, short)
+
+c:check("cycle1: 直後はまだ進路鎖錠が済んでいないのでHRは扛上しない",
+    sw.nt:get_signal("NHB5R").HR, false)
+
+----------------------------------------------------------------
+-- 以後、6サイクル(script.luaのonTickが6回=1論理サイクルに相当。h.tick()の
+-- 1回呼び出しがこれと同じ)ごとに在線状態を切り替えながら、その時々の状態を確認します
+----------------------------------------------------------------
+
+-- 1サイクル目: 在線なしのまま進める → 進路鎖錠が成立してHRが扛上する想定
+h.tick(sw, short)
+c:check("cycle2: 進路鎖錠成立でHRが扛上する", sw.nt:get_signal("NHB5R").HR, true)
+
+-- 2サイクル目: 列車が着点(NHB5RT)に進入(在線あり)
+short["NHB5RT"] = true
+h.tick(sw, short)
+c:check("cycle3: 在線した瞬間にHRは停止に落ちる", sw.nt:get_signal("NHB5R").HR, false)
+
+-- 3サイクル目: 列車が引き続き在線
+h.tick(sw, short)
+c:check("cycle4: 在線が続く間、HRは停止のまま", sw.nt:get_signal("NHB5R").HR, false)
+
+-- 4サイクル目: 列車が抜けて非在線に戻る
+short["NHB5RT"] = false
+h.tick(sw, short)
+c:check("cycle5: 通過直後、進路鎖錠が生き残っていればHRが再び扛上する",
+    sw.nt:get_signal("NHB5R").HR, true)
+
+c:report()

--- a/tests/run_all.js
+++ b/tests/run_all.js
@@ -1,0 +1,52 @@
+// tests/repro_*.lua をすべて実行し、まとめて結果を表示します。
+//
+// 実行方法: npm test
+// (pretest で node tests/gen_res.js が自動実行され、本番データから
+//  res/area_track.lua / res/signal.lua を作り直してから走ります)
+//
+// 各テストファイルは lua コマンドの別プロセスとして実行するため、
+// 1ファイルの中の状態が他のテストファイルに漏れることはありません。
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+process.chdir(path.join(__dirname, ".."));
+
+const dir = "tests";
+const files = fs.readdirSync(dir)
+    .filter((f) => /^repro_.*\.lua$/.test(f))
+    .sort();
+
+if (files.length === 0) {
+    console.log("tests/repro_*.lua が見つかりませんでした。");
+    process.exit(0);
+}
+
+const results = files.map((file) => {
+    const rel = path.join(dir, file);
+    const proc = spawnSync("lua", [rel], { encoding: "utf8" });
+    return {
+        file: rel,
+        ok: proc.status === 0,
+        output: (proc.stdout || "") + (proc.stderr || ""),
+    };
+});
+
+console.log("=".repeat(60));
+for (const r of results) {
+    console.log(`[${r.ok ? "PASS" : "FAIL"}] ${r.file}`);
+    if (!r.ok) {
+        // 失敗時は [NG] 行と集計行、Luaのエラー行だけ抜き出して表示する
+        r.output.split("\n")
+            .filter((l) => l.includes("[NG]") || l.includes("アサーション") || l.includes("lua:"))
+            .forEach((l) => console.log("    " + l));
+    }
+}
+console.log("=".repeat(60));
+
+const passCount = results.filter((r) => r.ok).length;
+console.log(`${passCount} / ${results.length} 件のテストファイルが成功しました`);
+
+if (passCount !== results.length) {
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary

- 実地テストで見つかったバグを、Stormworksを介さずLua単体で再現・固定化できるテストのひな形を追加
- `tests/gen_res.js` が `res/area_track.json` / `res/signal.toml`（本番データ）から `res/area_track.lua` / `res/signal.lua` を生成し、`tests/harness.lua` の `new_production_sw()` で本番と同じ信号機・軌道回路名（`NHB5R` など）をそのまま使ってテストが書けるようにした
- `tests/repro_template.lua` は「てこ操作→スタートtick→在線を切り替えながら毎サイクルassert」というひな形。実際に動かして全assertion成功を確認済み
- `npm test` で `tests/repro_*.lua` を一括実行し、PASS/FAIL一覧と失敗assertionだけを抜き出すサマリランナー（`tests/run_all.js`）を追加。1件でも失敗すれば非0終了

## Notes

- 調査中、リポジトリ直下の既存 `test.lua` が参照する `WAK1R` / `WAK1RT` が現在の `res/signal.toml` / `area_track.json` に存在せず実行できない状態であることに気づいたため、`tests/README.md` に注記した（今回のPRでは修正していません）

## Test plan

- [x] `node tests/gen_res.js` で本番データから `res/*.lua` を生成できることを確認
- [x] `lua tests/repro_template.lua` が全assertion成功することを確認
- [x] `npm test` が単体実行・複数ファイル実行の両方で正しいサマリ（PASS/FAIL件数、失敗行の抜粋）を表示することを確認（ダミーの失敗テストを一時的に追加して検証）


---
_Generated by [Claude Code](https://claude.ai/code/session_01RYzwoQn8QfGA9n3bQ6nkdF)_