### PR TITLE
route_lock/signal_trackのtrack連続性を自動チェックする機構を追加

### DIFF
--- a/build/check_route_continuity.js
+++ b/build/check_route_continuity.js
@@ -1,0 +1,102 @@
+// area_track.json の area 同士の隣接関係(uparea/downarea)から track 同士の
+// 隣接関係を求め、signal.toml の各進路(route_lock)・信号(signal_track)が
+// track を飛ばすことなく start から destination まで繋がっているかを検証する。
+
+function buildTrackAdjacency(areaTrackObj) {
+    const areas = new Map();
+    areaTrackObj.areas.forEach((a) => areas.set(a.name, a));
+
+    const downarea = new Map();
+    areaTrackObj.areas.forEach((a) => {
+        (a.uparea || []).forEach((upName) => {
+            if (!areas.has(upName)) return;
+            if (!downarea.has(upName)) downarea.set(upName, []);
+            downarea.get(upName).push(a.name);
+        });
+    });
+
+    const areaToTracks = new Map();
+    areaTrackObj.tracks.forEach((t) => {
+        t.areas.forEach((a) => {
+            if (!areaToTracks.has(a.name)) areaToTracks.set(a.name, []);
+            areaToTracks.get(a.name).push(t.name);
+        });
+    });
+
+    const adjacency = new Map();
+    const addEdge = (a, b) => {
+        if (a === b) return;
+        if (!adjacency.has(a)) adjacency.set(a, new Set());
+        if (!adjacency.has(b)) adjacency.set(b, new Set());
+        adjacency.get(a).add(b);
+        adjacency.get(b).add(a);
+    };
+
+    areaTrackObj.areas.forEach((a) => {
+        const myTracks = areaToTracks.get(a.name) || [];
+        if (myTracks.length === 0) return;
+        const neighbors = [...(a.uparea || []), ...(downarea.get(a.name) || [])];
+        neighbors.forEach((nb) => {
+            const nbTracks = areaToTracks.get(nb) || [];
+            myTracks.forEach((mt) => nbTracks.forEach((nt) => addEdge(mt, nt)));
+        });
+    });
+
+    return adjacency;
+}
+
+function isAdjacent(adjacency, a, b) {
+    if (a === b) return true;
+    return adjacency.has(a) && adjacency.get(a).has(b);
+}
+
+function findChainBreaks(adjacency, chain) {
+    const breaks = [];
+    for (let i = 0; i < chain.length - 1; i++) {
+        if (!isAdjacent(adjacency, chain[i], chain[i + 1])) {
+            breaks.push([chain[i], chain[i + 1]]);
+        }
+    }
+    return breaks;
+}
+
+function checkRouteTrackContinuity(signalObj, areaTrackObj) {
+    const adjacency = buildTrackAdjacency(areaTrackObj);
+    const errors = [];
+
+    Object.entries(signalObj).forEach(([name, data]) => {
+        if (data.opening_lever === true) return;
+
+        if (data.auto === true) {
+            const chain = data.signal_track || [];
+            findChainBreaks(adjacency, chain).forEach(([a, b]) => {
+                errors.push(`[${name}] signal_track: '${a}' と '${b}' の間が隣接track一覧に見つかりません (${chain.join(" -> ")})`);
+            });
+            return;
+        }
+
+        if (!data.start || !data.destination) return;
+
+        const routeChain = [data.start, ...(data.route_lock || []), data.destination];
+        findChainBreaks(adjacency, routeChain).forEach(([a, b]) => {
+            errors.push(`[${name}] route_lock: '${a}' と '${b}' の間が隣接track一覧に見つかりません (start=${data.start} -> destination=${data.destination}, chain=${routeChain.join(" -> ")})`);
+        });
+
+        if (data.signal_track && data.signal_track.length > 0) {
+            const signalChain = [data.start, ...data.signal_track];
+            findChainBreaks(adjacency, signalChain).forEach(([a, b]) => {
+                errors.push(`[${name}] signal_track: '${a}' と '${b}' の間が隣接track一覧に見つかりません (start=${data.start}, chain=${signalChain.join(" -> ")})`);
+            });
+        }
+    });
+
+    if (errors.length > 0) {
+        console.error("Route track continuity check failed:\n" + errors.join("\n"));
+    } else {
+        console.log("Route track continuity check: OK");
+    }
+
+    return errors;
+}
+
+module.exports = { checkRouteTrackContinuity, buildTrackAdjacency };

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const path = require("path");
 const toml = require("toml");
 const generateAreaTrack = require("./build/generate_area_track");
 const { generateSignal, buildControlsMap, detectControlsCycle } = require("./build/generate_signal");
+const { checkRouteTrackContinuity } = require("./build/check_route_continuity");
 require('dotenv').config();
 
 process.chdir(__dirname);
@@ -79,7 +80,9 @@ async function main() {
         fs.promises.readFile("res/area_track.json", "utf8"),
     ]);
     const signalObj = toml.parse(signalSrc);
-    checkCrossReferences(signalObj, JSON.parse(areaTrackSrc));
+    const areaTrackObj = JSON.parse(areaTrackSrc);
+    checkCrossReferences(signalObj, areaTrackObj);
+    checkRouteTrackContinuity(signalObj, areaTrackObj);
     detectOpeningLeverConflicts(signalObj);
 
     if (isStale("res/signal.lua", "res/signal.toml")) {


### PR DESCRIPTION
## Summary
- `area_track.json` の area 同士の隣接関係(`uparea`/`downarea`)から track 同士の隣接グラフを構築し、`signal.toml` の各進路(`route_lock`)・信号(`signal_track`)が `start` から `destination` まで track を飛ばすことなく繋がっているかを build 時に検証する `build/check_route_continuity.js` を追加
- `index.js` の `main()` に組み込み、既存の `checkCrossReferences` と同様に警告のみ(`console.error`)でbuildは止めない扱いとした

## Background
TKM(高見が丘)駅のtrackネットワーク構造を確認する過程で、`route_lock`/`signal_track` が隣接trackを飛ばしている箇所(`TKM4L`, `TKM15L`)や、`destination` と無関係なtrackを指していた箇所(`NHB2R`)を手動で発見した。この確認作業を継続的に自動化できるよう、同じロジックをbuildスクリプトに組み込んだ。
(なお、発見した3件のバグは本PR作成前に `develop` 側で別途修正済み。現状のデータではこのチェックは0件で通過する)

## Test plan
- [x] `node index.js` を実行し、`Route track continuity check: OK` が出力されることを確認
- [x] チェックロジック単体で、修正前のデータ(3件のバグを含む状態)に対して意図通り全件検出することを確認済み(TKM4L, TKM15L, NHB2Rの計7件のchain break)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NgQPNZhGzuUEWAPAmdcn6v)_